### PR TITLE
Wrong executable name in launch files

### DIFF
--- a/robotiq_2f_140_gripper_visualization/launch/test_2f_140_model.launch
+++ b/robotiq_2f_140_gripper_visualization/launch/test_2f_140_model.launch
@@ -5,6 +5,6 @@
   <param name="robot_description" command="$(find xacro)/xacro $(find robotiq_2f_140_gripper_visualization)/urdf/robotiq_arg2f_140_model.xacro" />
   <param name="use_gui" value="$(arg gui)"/>
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find robotiq_2f_140_gripper_visualization)/visualize.rviz" required="true" />
 </launch>

--- a/robotiq_2f_85_gripper_visualization/launch/test_2f_85_model.launch
+++ b/robotiq_2f_85_gripper_visualization/launch/test_2f_85_model.launch
@@ -7,7 +7,7 @@
   <param name="robot_description" command="$(find xacro)/xacro $(find robotiq_2f_85_gripper_visualization)/urdf/robotiq_arg2f_85_model.xacro" />
 
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find robotiq_2f_85_gripper_visualization)/visualize.rviz" required="true" />
 </launch>

--- a/robotiq_2f_c2_gripper_visualization/launch/test_robotiq_c2_model.launch
+++ b/robotiq_2f_c2_gripper_visualization/launch/test_robotiq_c2_model.launch
@@ -5,6 +5,6 @@
   <param name="robot_description" command="$(find xacro)/xacro $(find robotiq_2f_c2_gripper_visualization)/urdf/robotiq_c2_model.xacro" />
   <param name="use_gui" value="$(arg gui)"/>
   <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-  <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+  <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
   <node name="rviz" pkg="rviz" type="rviz" args="-d $(find robotiq_2f_c2_gripper_visualization)/visualize.rviz" required="true" />
 </launch>

--- a/robotiq_3f_gripper_articulated_gazebo/launch/robotiq_gripper_empty_world.launch
+++ b/robotiq_3f_gripper_articulated_gazebo/launch/robotiq_gripper_empty_world.launch
@@ -12,7 +12,7 @@
   </include>
 
   <!-- Start the publisher for the left hand (the only hand) -->
-  <node pkg="robot_state_publisher" type="state_publisher" name="robotiq_hands_l_hand_robot_state_publisher">
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="robotiq_hands_l_hand_robot_state_publisher">
     <param name="publish_frequency" type="double" value="50.0" />
     <remap from="joint_states" to="/robotiq_hands/left_hand/joint_states" />
   </node>


### PR DESCRIPTION
The **type** attribute of **node** tag is the name of the executable from the ROS package. There is no `state_publisher` executable in `robot_state_publisher` package.