### PR TITLE
Missing queue_size in publishers

### DIFF
--- a/robotiq_2f_gripper_control/nodes/Robotiq2FGripperRtuNode.py
+++ b/robotiq_2f_gripper_control/nodes/Robotiq2FGripperRtuNode.py
@@ -63,7 +63,7 @@ def mainLoop(device):
 
     # The Gripper status is published on the topic named 'Robotiq2FGripperRobotInput'
     pub = rospy.Publisher(
-        "Robotiq2FGripperRobotInput", inputMsg.Robotiq2FGripper_robot_input
+        "Robotiq2FGripperRobotInput", inputMsg.Robotiq2FGripper_robot_input, queue_size=10
     )
 
     # The Gripper command is received from the topic named 'Robotiq2FGripperRobotOutput'

--- a/robotiq_2f_gripper_control/nodes/Robotiq2FGripperSimpleController.py
+++ b/robotiq_2f_gripper_control/nodes/Robotiq2FGripperSimpleController.py
@@ -133,7 +133,7 @@ def publisher():
     rospy.init_node("Robotiq2FGripperSimpleController")
 
     pub = rospy.Publisher(
-        "Robotiq2FGripperRobotOutput", outputMsg.Robotiq2FGripper_robot_output
+        "Robotiq2FGripperRobotOutput", outputMsg.Robotiq2FGripper_robot_output, queue_size=10
     )
 
     command = outputMsg.Robotiq2FGripper_robot_output()

--- a/robotiq_2f_gripper_control/nodes/Robotiq2FGripperTcpNode.py
+++ b/robotiq_2f_gripper_control/nodes/Robotiq2FGripperTcpNode.py
@@ -64,7 +64,7 @@ def mainLoop(address):
 
     # The Gripper status is published on the topic named 'Robotiq2FGripperRobotInput'
     pub = rospy.Publisher(
-        "Robotiq2FGripperRobotInput", inputMsg.Robotiq2FGripper_robot_input
+        "Robotiq2FGripperRobotInput", inputMsg.Robotiq2FGripper_robot_input, queue_size=10
     )
 
     # The Gripper command is received from the topic named 'Robotiq2FGripperRobotOutput'

--- a/robotiq_2f_gripper_control/src/robotiq_2f_gripper_control/robotiq_2f_gripper_ctrl.py
+++ b/robotiq_2f_gripper_control/src/robotiq_2f_gripper_control/robotiq_2f_gripper_ctrl.py
@@ -12,7 +12,7 @@ class RobotiqCGripper(object):
         self.status_sub = rospy.Subscriber(
             "Robotiq2FGripperRobotInput", inputMsg, self._status_cb
         )
-        self.cmd_pub = rospy.Publisher("Robotiq2FGripperRobotOutput", outputMsg)
+        self.cmd_pub = rospy.Publisher("Robotiq2FGripperRobotOutput", outputMsg, queue_size=10)
 
     def _status_cb(self, msg):
         self.cur_status = msg


### PR DESCRIPTION
As of ROS Indigo not passing the keyword argument _queue_size_ will result in a warning being printed to the console ([source](http://wiki.ros.org/rospy/Overview/Publishers%20and%20Subscribers#Choosing_a_good_queue_size))